### PR TITLE
Fix for app crash caused by code attempting to start a background thread...

### DIFF
--- a/ClearBladeAPI/CBMessageClient.m
+++ b/ClearBladeAPI/CBMessageClient.m
@@ -250,7 +250,10 @@ static void CBMessageClient_onPublish(struct mosquitto * mosq, void *voidClient,
     id<CBMessageClientDelegate> delegate = self.delegate;
     switch (response) {
         case MOSQ_ERR_SUCCESS:
-            [self.clientThread start];
+            if (![self.clientThread isExecuting])
+            {
+                [self.clientThread start];
+            }
             break;
         case MOSQ_ERR_INVAL:
             if ([delegate respondsToSelector:@selector(messageClient:didFailToConnect:)]) {


### PR DESCRIPTION
... that is already executing

We were seeing a large number of app crashes related to the '[self.clientThread start];' line of code.  I can not reliably reproduce the issue but this pull request should prevent the app crash.
