### PR TITLE
Added support for including the 'content-available' attribute in APS not...

### DIFF
--- a/ClearBladeAPI/CBPush.m
+++ b/ClearBladeAPI/CBPush.m
@@ -61,7 +61,7 @@
     [parsedDict setObject:[[NSMutableDictionary alloc] init] forKey:@"aps"];
     
     for(NSString* key in dict){
-        if ([key isEqualToString:@"alert"] || [key isEqualToString:@"badge"] || [key isEqualToString:@"sound"]) {
+        if ([key isEqualToString:@"alert"] || [key isEqualToString:@"badge"] || [key isEqualToString:@"sound"] || [key isEqualToString:@"content-available"]) {
             [[parsedDict objectForKey:@"aps"] setObject:dict[key] forKey:key];
         }else{
             [parsedDict setObject:dict[key] forKey:key];


### PR DESCRIPTION
...ifications

Apple devices support the 'content-available' attribute which allows an app to wake up and process data in the background.  
