### PR TITLE
Fixed crash bug caused by improper handling of HTML 400 and 500 errors

### DIFF
--- a/CBAPITests/AsyncTestCase.h
+++ b/CBAPITests/AsyncTestCase.h
@@ -18,6 +18,9 @@
 #define AUTH_APP_KEY @"d0ef9daf0acaebd9d581ce88df4a"
 #define AUTH_APP_SECRET @"D0EF9DAF0ABAC098A0F6DF8D85AE01"
 
+#define TOKEN_APP_KEY @"c8e69eff0ab4cf90a8acf8fae204"
+#define TOKEN_APP_SECRET @"C8E69EFF0AC0A798B9F7F3BB981E"
+
 #define TEST_COLLECTION @"e889a4ab0ac69af5bbbba3ebfa2b"
 #define AUTH_TEST_COLLECTION @"b6b1b0b10ac8beb08a9ed9f1cfd301"
 #define PLATFORM_ADDRESS @"https://platform.clearblade.com/"

--- a/CBAPITests/CBUserTests.m
+++ b/CBAPITests/CBUserTests.m
@@ -139,6 +139,95 @@
     [self waitForAsyncCompletion:MAIN_COMPLETION];
 }
 
+/**
+ An expired token returns an HTML Status Code 400
+ */
+-(void)testGetUserInfoWithExpiredToken {
+
+    XCTestExpectation*  expectation = [self expectationWithDescription:@"testGetUserInfoWithExpiredToken"];
+    
+    NSString * email = @"rob@clearblade.com";
+    NSString* token = @"D2UuYhlQp1H5OcWjrP4SuQ63E7RcKdNXzwI4h57KLC-YjeW74o2u2-O_mLA_sBejjogMqbHjGp_JKZLT_A==";
+    NSDictionary* options = @{
+                              CBSettingsOptionServerAddress: PLATFORM_ADDRESS,
+                              CBSettingsOptionLoggingLevel: @(TEST_LOGGING_LEVEL),
+                              CBSettingsOptionEmail:email,
+                              CBSettingsOptionPassword:@"clearblade"};
+    
+    [ClearBlade
+       initSettingsWithSystemKey:@"c8e69eff0ab4cf90a8acf8fae204"
+       withSystemSecret:@"C8E69EFF0AC0A798B9F7F3BB981E"
+       withOptions:options
+       withSuccessCallback:^(ClearBlade *settings) {
+        
+        CBUser *user = [CBUser authenticatedUserWithEmail:email withAuthToken:token];
+        settings.mainUser = user;
+        
+        NSError *getUserInfoError;
+        [user getCurrentUserInfoWithError:&getUserInfoError];
+        if (getUserInfoError != nil) {
+            // We expect an error here because the token is invalid or expired
+            [expectation fulfill];
+        }
+		else{
+			XCTFail(@"We succeeded when we should have failed.");
+        }
+    }
+      withErrorCallback:^(NSError * error) {
+		
+            XCTFail(@"Failed to init ClearBlade. Error: <%@>", error);
+
+            
+        }];
+    
+    [self waitForExpectationsWithTimeout:10.0 handler:nil];
+}
+
+/**
+ An expired token returns an HTML Status Code 400
+ */
+
+-(void)testGetUserInfoWithInvalidToken {
+    
+    XCTestExpectation* expectation = [self expectationWithDescription:@"testGetUserInfoWithInvalidToken"];
+    
+    NSString * email = @"rob@clearblade.com";
+    NSString* token = @"Invalidtoken";
+    NSDictionary* options = @{
+                              CBSettingsOptionServerAddress: PLATFORM_ADDRESS,
+                              CBSettingsOptionLoggingLevel: @(TEST_LOGGING_LEVEL),
+                              CBSettingsOptionEmail:email,
+                              CBSettingsOptionPassword:@"clearblade"};
+    
+    [ClearBlade
+      initSettingsWithSystemKey:@"c8e69eff0ab4cf90a8acf8fae204"
+      withSystemSecret:@"C8E69EFF0AC0A798B9F7F3BB981E"
+      withOptions:options
+      withSuccessCallback:^(ClearBlade *settings) {
+        
+        CBUser *user = [CBUser authenticatedUserWithEmail:email withAuthToken:token];
+        settings.mainUser = user;
+        
+        NSError *getUserInfoError;
+        [user getCurrentUserInfoWithError:&getUserInfoError];
+        if (getUserInfoError != nil) {
+            // We expect an error here because the token is invalid or expired
+            [expectation fulfill];
+        }
+        else{
+            XCTFail(@"Platform accepted an invalid token. We succeeded when we should have failed.");
+        }
+    }
+      withErrorCallback:^(NSError * error) {
+                            
+        XCTFail(@"Failed to init ClearBlade. Error: <%@>", error);
+                            
+                            
+      }
+	];
+    
+    [self waitForExpectationsWithTimeout:10.0 handler:nil];
+}
 /*
  Not testable at present
 -(void)testGetCount{

--- a/CBAPITests/CBUserTests.m
+++ b/CBAPITests/CBUserTests.m
@@ -155,8 +155,8 @@
                               CBSettingsOptionPassword:@"clearblade"};
     
     [ClearBlade
-       initSettingsWithSystemKey:@"c8e69eff0ab4cf90a8acf8fae204"
-       withSystemSecret:@"C8E69EFF0AC0A798B9F7F3BB981E"
+       initSettingsWithSystemKey:TOKEN_APP_KEY
+       withSystemSecret:TOKEN_APP_SECRET
        withOptions:options
        withSuccessCallback:^(ClearBlade *settings) {
         
@@ -200,8 +200,8 @@
                               CBSettingsOptionPassword:@"clearblade"};
     
     [ClearBlade
-      initSettingsWithSystemKey:@"c8e69eff0ab4cf90a8acf8fae204"
-      withSystemSecret:@"C8E69EFF0AC0A798B9F7F3BB981E"
+      initSettingsWithSystemKey:TOKEN_APP_KEY
+      withSystemSecret:TOKEN_APP_SECRET
       withOptions:options
       withSuccessCallback:^(ClearBlade *settings) {
         

--- a/ClearBladeAPI/CBUser.m
+++ b/ClearBladeAPI/CBUser.m
@@ -274,13 +274,17 @@
 }
 
 -(NSDictionary *)getCurrentUserInfoWithError:(NSError *__autoreleasing *)error {
-    NSData *data = [[CBUser getUserInfoRequestWithSettings:[ClearBlade settings] withToken:self.authToken] executeWithError:error];
+    CBHTTPRequest* request = [CBUser getUserInfoRequestWithSettings:[ClearBlade settings] withToken:self.authToken];
+    NSData *data = [request executeWithError:error];
+    NSDictionary *userInfo = @{};
     if (*error) {
         CBLogError(@"Failed to get user info of user <%@> because of error <%@>", self, *error);
     }
-    NSDictionary *userInfo = [NSJSONSerialization JSONObjectWithData:data options:kNilOptions error:error];
-    if (*error) {
-        CBLogError(@"Failed to parse user info of user <%@> because of error <%@>", self, *error);
+    else{
+        userInfo = [NSJSONSerialization JSONObjectWithData:data options:kNilOptions error:error];
+    	if (*error) {
+        	CBLogError(@"Failed to parse user info of user <%@> because of error <%@>", self, *error);
+    	}
     }
     return userInfo;
 }


### PR DESCRIPTION
CBUser.m:276 #getCurrentUserInfoWithError

Token has expired. Response data returned nil because platform responded with 400- or 500-level response code. Execution flow needed to leave the function, but instead was called upon and caused app to crash.