### PR TITLE
Staging - Added 2 nil checks in CBUser's #getCurrentUserInfoWithError, Added 2 Unit Tests

### DIFF
--- a/CBAPI.xcodeproj/xcshareddata/xcschemes/CBAPI.xcscheme
+++ b/CBAPI.xcodeproj/xcshareddata/xcschemes/CBAPI.xcscheme
@@ -23,10 +23,10 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Debug">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -37,43 +37,26 @@
                BlueprintName = "CBAPITests"
                ReferencedContainer = "container:CBAPI.xcodeproj">
             </BuildableReference>
-            <SkippedTests>
-               <Test
-                  Identifier = "CBUserTests/testFailedRequestToGetUserInfoWithExpiredToken">
-               </Test>
-            </SkippedTests>
          </TestableReference>
       </Testables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
-      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "8D6EBC6E1868B6EE0083623F"
-            BuildableName = "CBAPITests.xctest"
-            BlueprintName = "CBAPITests"
-            ReferencedContainer = "container:CBAPI.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
-      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
    </ProfileAction>
    <AnalyzeAction

--- a/CBAPI.xcodeproj/xcshareddata/xcschemes/CBAPI.xcscheme
+++ b/CBAPI.xcodeproj/xcshareddata/xcschemes/CBAPI.xcscheme
@@ -23,10 +23,10 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -37,26 +37,43 @@
                BlueprintName = "CBAPITests"
                ReferencedContainer = "container:CBAPI.xcodeproj">
             </BuildableReference>
+            <SkippedTests>
+               <Test
+                  Identifier = "CBUserTests/testFailedRequestToGetUserInfoWithExpiredToken">
+               </Test>
+            </SkippedTests>
          </TestableReference>
       </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8D6EBC6E1868B6EE0083623F"
+            BuildableName = "CBAPITests.xctest"
+            BlueprintName = "CBAPITests"
+            ReferencedContainer = "container:CBAPI.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
    </ProfileAction>
    <AnalyzeAction

--- a/ClearBladeAPI/CBUser.m
+++ b/ClearBladeAPI/CBUser.m
@@ -274,9 +274,26 @@
 }
 
 -(NSDictionary *)getCurrentUserInfoWithError:(NSError *__autoreleasing *)error {
-    CBHTTPRequest* request = [CBUser getUserInfoRequestWithSettings:[ClearBlade settings] withToken:self.authToken];
-    NSData *data = [request executeWithError:error];
     NSDictionary *userInfo = @{};
+    
+    if(!self.authToken){
+        
+        *error = [NSError errorWithDomain:@"Unable to complete request because auth token was not set. You must initialize ClearBlade before use."
+                            code:400
+                        userInfo:nil];
+        return userInfo;
+    }
+    
+    CBHTTPRequest* request = [CBUser getUserInfoRequestWithSettings:[ClearBlade settings] withToken:self.authToken];
+    
+    if(!request){
+        *error = [NSError errorWithDomain:@"Unable to complete request because invalid settings were found."
+                                     code:400
+                                 userInfo:nil];
+        return userInfo;    }
+    
+    NSData *data = [request executeWithError:error];
+    
     if (*error) {
         CBLogError(@"Failed to get user info of user <%@> because of error <%@>", self, *error);
     }


### PR DESCRIPTION
Neither authToken or CBHTTPRequest are expected to be nil, but we do now add a nil check to ensure error handling in that case.
